### PR TITLE
Fix errors when value's don't exist (Moonkin)

### DIFF
--- a/rotations/druid/balance.lua
+++ b/rotations/druid/balance.lua
@@ -122,8 +122,8 @@ local BoomkinForm = {
 	}, "toggle.dotEverything" },
 
 	-- AoE
-		{ "48505", (function() return NeP.Lib.SAoE(3, 40) end), "target" }, -- Starfall
-		{ "48505", "player.area(8).enemies >= 4", "target" }, -- Starfall  // FH SMART AoE
+		{ "48505", { (function() return NeP.Lib.SAoE(3, 40) end), "!player.buff(184989)" }}, -- Starfall
+		{ "48505", { "player.area(8).enemies >= 4", "!player.buff(184989)" }}, -- Starfall  // FH SMART AoE
 	
 	-- Proc's
 		{ "78674", "player.buff(Shooting Stars)", "target" }, --Starsurge with Shooting Stars Proc

--- a/rotations/druid/balance.lua
+++ b/rotations/druid/balance.lua
@@ -3,18 +3,18 @@ NeP.Addon.Interface.DruidBalance = {
 	profiles = true,
 	title = NeP.Addon.Info.Icon.."MrTheSoulz Config",
 	subtitle = "Druid Balance Settings",
-	color = NeP.Core.classColor('player'),
+	color = NeP.Core.classColor("player"),
 	width = 250,
 	height = 500,
 	config = {
 		
 		-- General
-		{ type = 'rule' },
-		{ type = 'header', text = "General settings:", align = "center"},
+		{ type = "rule" },
+		{ type = "header", text = "General settings:", align = "center" },
 
 			-- Buff
 			{ type = "checkbox", text = "Buffs", key = "Buffs", default = true, desc =
-			 "This checkbox enables or disables the use of automatic buffing."},
+			 "This checkbox enables or disables the use of automatic buffing." },
 
 			{ 
 		      	type = "dropdown",
@@ -90,17 +90,17 @@ local exeOnLoad = function()
 	NeP.Splash()
 
   	ProbablyEngine.toggle.create(
-		'dotEverything', 
-		'Interface\\Icons\\Ability_creature_cursed_05.png', 
-		'Dot All The Things!', 
-		'Click here to dot all the things!\nSome Spells require Multitarget enabled also.\nOnly Works if using FireHack.')
+		"dotEverything", 
+		"Interface\\Icons\\Ability_creature_cursed_05.png", 
+		"Dot All The Things!", 
+		"Click here to dot all the things!\nSome Spells require Multitarget enabled also.\nOnly Works if using FireHack.")
 end
 
 local BoomkinForm = {
 			
 	{{-- Interrupts
 		{ "78675" }, -- Solar Beam
-	}, "target.interruptsAt("..(NeP.Core.PeFetch('npconf', 'ItA')  or 40)..")" },
+	}, "target.interruptsAt("..(NeP.Core.PeFetch("npconf", "ItA", 40))..")" },
 	
 	-- Items
 		{ "#5512", "player.health < 50" }, --Healthstone
@@ -113,12 +113,12 @@ local BoomkinForm = {
  
 	--Defensive
 		{ "Barkskin", "player.health <= 50", "player" },
-		{ "#5512", "player.health < 40"}, --Healthstone when less than 40% health
-		{ "108238", "player.health < 60", "player"}, --Instant renewal when less than 40% health
+		{ "#5512", "player.health < 40" }, --Healthstone when less than 40% health
+		{ "108238", "player.health < 60", "player" }, --Instant renewal when less than 40% health
 	
 	{{ -- Auto Dotting	
-		{ "164812", (function() return NeP.Lib.AutoDots('164812', 100, 2) end) }, -- moonfire
-		{ "164815", (function() return NeP.Lib.AutoDots('164815', 100, 2) end) }, --SunFire
+		{ "164812", (function() return NeP.Lib.AutoDots("164812", 100, 2) end) }, -- moonfire
+		{ "164815", (function() return NeP.Lib.AutoDots("164815", 100, 2) end) }, --SunFire
 	}, "toggle.dotEverything" },
 
 	-- AoE
@@ -131,10 +131,10 @@ local BoomkinForm = {
 		{ "164812", "player.buff(Lunar Peak)", "target" }, --MoonFire on proc
 	
 	-- Rotation
-		{ "78674", "player.spell(78674).charges >= 2" }, --StarSurge with more then 2 charges
-		{ "78674", "player.buff(112071)" }, --StarSurge with Celestial Alignment buff
-		{ "164812", "target.debuff(Moonfire).duration <= 2"}, --MoonFire
-		{ "164815", "target.debuff(Sunfire).duration <= 2"}, --SunFire
+		{ "78674", { "player.spell(78674).charges >= 2", "!lastcast(78674)" } }, --StarSurge with more then 2 charges
+		{ "78674", { "player.buff(112071)", "!lastcast(78674)" } }, --StarSurge with Celestial Alignment buff
+		{ "164812", "target.debuff(Moonfire).duration <= 2" }, --MoonFire
+		{ "164815", "target.debuff(Sunfire).duration <= 2" }, --SunFire
 		{ "2912", "player.buff(Lunar Empowerment).count >= 1" }, --Starfire with Lunar Empowerment
 		{ "5176", "player.buff(Solar Empowerment).count >= 1" }, --Wrath with Solar Empowerment
 		{ "2912", { ( function() return UnitPower( "player", SPELL_POWER_ECLIPSE ) <= 20 end ), "player.lunar" } }, --StarFire
@@ -144,7 +144,7 @@ local BoomkinForm = {
 		--{ "2912" }, --StarFire Filler
 }
 
-ProbablyEngine.rotation.register_custom(102, NeP.Core.GetCrInfo('Druid - Balance'), 
+ProbablyEngine.rotation.register_custom(102, NeP.Core.GetCrInfo("Druid - Balance"), 
 	{ ------------------------------------------------------------------------------------------------------------------ In Combat
 		{ "1126", {  -- Mark of the Wild
 			"!player.buff(20217).any", -- kings
@@ -154,44 +154,44 @@ ProbablyEngine.rotation.register_custom(102, NeP.Core.GetCrInfo('Druid - Balance
 			"!player.buff(69378).any",  -- Blessing of Forgotten Kings
 			"!player.buff(5215)",-- Not in Stealth
 			"player.form = 0", -- Player not in form
-			(function() return NeP.Core.PeFetch('npconfDruidBalance','Buffs') end),
+			(function() return NeP.Core.PeFetch("npconfDruidBalance", "Buffs", true) end),
 		}},
 		{ "20484", { -- Rebirth
 			"modifier.lshift", 
 			"!mouseover.alive" 
 		}, "mouseover" },
-	  	{ "/run CancelShapeshiftForm();", (function() 
-	  		if NeP.Core.dynamicEval("player.form = 0") or NeP.Core.PeFetch('npconfDruidBalance', 'Form') == 'MANUAL' then
+	  	{ "/run CancelShapeshiftForm()", (function() 
+	  		if NeP.Core.dynamicEval("player.form = 0") or NeP.Core.PeFetch("npconfDruidBalance", "Form", "4") == "MANUAL" then
 	  			return false
-	  		elseif NeP.Core.dynamicEval("player.form != 0") and NeP.Core.PeFetch('npconfDruidBalance', 'Form') == '0' then
+	  		elseif NeP.Core.dynamicEval("player.form != 0") and NeP.Core.PeFetch("npconfDruidBalance", "Form", "4") == "0" then
 	  			return true
 	  		else
-	  			return NeP.Core.dynamicEval("player.form != " .. NeP.Core.PeFetch('npconfDruidBalance', 'Form'))
+	  			return NeP.Core.dynamicEval("player.form != " .. NeP.Core.PeFetch("npconfDruidBalance", "Form", "4"))
 	  		end
 	  	end) },
 		{ "768", { -- catform
 	  		"player.form != 2", -- Stop if cat
 	  		"!modifier.lalt", -- Stop if pressing left alt
 	  		"!player.buff(5215)", -- Not in Stealth
-	  		(function() return NeP.Core.PeFetch('npconfDruidBalance','Form') == '2' end),
+	  		(function() return NeP.Core.PeFetch("npconfDruidBalance", "Form", "4") == "2" end),
 	  	}},
 	  	{ "783", { -- Travel
 	  		"player.form != 3", -- Stop if cat
 	  		"!modifier.lalt", -- Stop if pressing left alt
 	  		"!player.buff(5215)", -- Not in Stealth
-	  		(function() return NeP.Core.PeFetch('npconfDruidBalance','Form') == '3' end),
+	  		(function() return NeP.Core.PeFetch("npconfDruidBalance", "Form", "4") == "3" end),
 	  	}},
 	  	{ "5487", { -- catform
 	  		"player.form != 1", -- Stop if cat
 	  		"!modifier.lalt", -- Stop if pressing left alt
 	  		"!player.buff(5215)", -- Not in Stealth
-	  		(function() return NeP.Core.PeFetch('npconfDruidBalance','Form') == '1' end),
+	  		(function() return NeP.Core.PeFetch("npconfDruidBalance", "Form", "4") == "1" end),
 	  	}},
 	  	{ "24858", { -- boomkin
 	  		"player.form != 4", -- Stop if boomkin
 	  		"!modifier.lalt", -- Stop if pressing left alt
 	  		"!player.buff(5215)", -- Not in Stealth
-	  		(function() return NeP.Core.PeFetch('npconfDruidBalance','Form') == '4' end),
+	  		(function() return NeP.Core.PeFetch("npconfDruidBalance", "Form", "4") == "4" end),
 	  	}},
 	  	{{ --------------------------------------------------------------------------------- Boomkin Form
 	  		{ BoomkinForm },
@@ -206,43 +206,43 @@ ProbablyEngine.rotation.register_custom(102, NeP.Core.GetCrInfo('Druid - Balance
 			"!player.buff(69378).any",  -- Blessing of Forgotten Kings
 			"!player.buff(5215)",-- Not in Stealth
 			"player.form = 0", -- Player not in form
-			(function() return NeP.Core.PeFetch('npconfDruidBalance','Buffs') end),
+			(function() return NeP.Core.PeFetch("npconfDruidBalance", "Buffs", true) end),
 		}},
 		{ "20484", { -- Rebirth
 			"modifier.lshift", 
 			"!mouseover.alive" 
 		}, "mouseover" },
-	  	{ "/run CancelShapeshiftForm();", (function() 
-	  		if NeP.Core.dynamicEval("player.form = 0") or NeP.Core.PeFetch('npconfDruidBalance', 'FormOCC') == 'MANUAL' then
+	  	{ "/run CancelShapeshiftForm()", (function() 
+	  		if NeP.Core.dynamicEval("player.form = 0") or NeP.Core.PeFetch("npconfDruidBalance", "FormOCC", "4") == "MANUAL" then
 	  			return false
-	  		elseif NeP.Core.dynamicEval("player.form != 0") and NeP.Core.PeFetch('npconfDruidBalance', 'FormOCC') == '0' then
+	  		elseif NeP.Core.dynamicEval("player.form != 0") and NeP.Core.PeFetch("npconfDruidBalance", "FormOCC", "4") == "0" then
 	  			return true
 	  		else
-	  			return NeP.Core.dynamicEval("player.form != " .. NeP.Core.PeFetch('npconfDruidBalance', 'FormOCC'))
+	  			return NeP.Core.dynamicEval("player.form != " .. NeP.Core.PeFetch("npconfDruidBalance", "FormOCC", "4"))
 	  		end
 	  	end) },
 		{ "768", { -- catform
 	  		"player.form != 2", -- Stop if cat
 	  		"!modifier.lalt", -- Stop if pressing left alt
 	  		"!player.buff(5215)", -- Not in Stealth
-	  		(function() return NeP.Core.PeFetch('npconfDruidBalance','FormOCC') == '2' end),
+	  		(function() return NeP.Core.PeFetch("npconfDruidBalance", "FormOCC", "4") == "2" end),
 	  	}},
 	  	{ "783", { -- Travel
 	  		"player.form != 3", -- Stop if cat
 	  		"!modifier.lalt", -- Stop if pressing left alt
 	  		"!player.buff(5215)", -- Not in Stealth
-	  		(function() return NeP.Core.PeFetch('npconfDruidBalance','FormOCC') == '3' end),
+	  		(function() return NeP.Core.PeFetch("npconfDruidBalance", "FormOCC", "4") == "3" end),
 	  	}},
 	  	{ "5487", { -- catform
 	  		"player.form != 1", -- Stop if cat
 	  		"!modifier.lalt", -- Stop if pressing left alt
 	  		"!player.buff(5215)", -- Not in Stealth
-	  		(function() return NeP.Core.PeFetch('npconfDruidBalance','FormOCC') == '1' end),
+	  		(function() return NeP.Core.PeFetch("npconfDruidBalance", "FormOCC", "4") == "1" end),
 	  	}},
 		{ "24858", { -- boomkin
 	  		"player.form != 4", -- Stop if boomkin
 	  		"!modifier.lalt", -- Stop if pressing left alt
 	  		"!player.buff(5215)", -- Not in Stealth
-	  		(function() return NeP.Core.PeFetch('npconfDruidBalance','FormOCC') == '4' end),
+	  		(function() return NeP.Core.PeFetch("npconfDruidBalance", "FormOCC", "4") == "4" end),
 	  	}},
 	}, exeOnLoad)


### PR DESCRIPTION
This fixes the error of concatenate a nil value since npconfDruidBalance is not in the config.
FormOCC and Form default to 4 or Moonkin.
Also standardizes ' to " and "","" to "", "" (Totally not necessary. But for OCD-ish sake.)
Added "!lastcast(78674)" so it does not spam cast StarSurge.
Add check so it does not use all charges at once. ("!player.buff(184989)"). And remove "target" because it is a buff. (PE auto adds "target" when in combat anyway. So it does not change anything.)