### PR TITLE
Fix error 2

### DIFF
--- a/system/Overlays.lua
+++ b/system/Overlays.lua
@@ -58,7 +58,7 @@ LibDraw.Sync(function()
 			local playerX, playerY, playerZ = ObjectPosition('player')
 			--local cx, cy, cz = GetCameraPosition()
 
-			if UnitExists('target') then
+			if ObjectExists('target') then
 				local targetX, targetY, targetZ = ObjectPosition("target")
 				local distance = NeP.Core.Distance('player', 'target')
 				local name = UnitName("target")


### PR DESCRIPTION
NerdPack\system\Overlays.lua:62: The GUID does not belong to an existing object.
[C]: in function `ObjectPosition'
NerdPack\system\Overlays.lua:62: in function `callback'