### PR TITLE
updates to GenericFilter to use GUID properly & addition of GUID to O…

### DIFF
--- a/facerool.lua
+++ b/facerool.lua
@@ -100,14 +100,13 @@ function NeP.Engine.FaceRoll()
 	---------------------------------------------------]]
 	local function GenericFilter(unit)
 		if UnitExists(unit) then
-			local objectType, _, _, _, _, _id, _ = strsplit('-', UnitGUID(unit))
-			local GUID = tonumber(_id) or '0'
+			local GUID = UnitGUID(unit)
 			local alreadyExists = false
 			-- Enemie Filter
 			if UnitCanAttack('player', unit) then
 				for i=1, #NeP.TempOM.unitEnemie do
 					local object = NeP.TempOM.unitEnemie[i]
-					if object.ID == GUID then
+					if object.guid == GUID then
 						alreadyExists = true
 					end
 				end
@@ -115,7 +114,7 @@ function NeP.Engine.FaceRoll()
 			elseif UnitIsFriend('player', unit) then
 				for i=1, #NeP.TempOM.unitFriend do
 					local object = NeP.TempOM.unitFriend[i]
-					if object.ID == GUID then
+					if object.guid == GUID then
 						alreadyExists = true
 					end
 				end

--- a/system/ObjectManager.lua
+++ b/system/ObjectManager.lua
@@ -174,7 +174,8 @@ NeP.TempOM = {
 function NeP.OM.addToOM(Obj)
 	if not BlacklistedObject(Obj) then
 		if not BlacklistedDebuffs(Obj) then
-			local objectType, _, _, _, _, _id, _ = strsplit('-', UnitGUID(Obj))
+			local GUID = UnitGUID(Obj)
+			local objectType, _, _, _, _, _id, _ = strsplit('-', GUID)
 			local ID = tonumber(_id) or '0'
 			-- Friendly
 			if UnitIsFriend('player', Obj) and UnitHealth(Obj) > 0 then
@@ -184,7 +185,8 @@ function NeP.OM.addToOM(Obj)
 					class = Classifications[tostring(UnitClassification(Obj))],
 					distance = NeP.Engine.Distance('player', Obj),
 					is = 'friendly',
-					id = ID
+					id = ID,
+					guid = GUID
 				}
 			-- Enemie
 			elseif UnitCanAttack('player', Obj) and UnitHealth(Obj) > 0 then
@@ -194,7 +196,8 @@ function NeP.OM.addToOM(Obj)
 					class = Classifications[tostring(UnitClassification(Obj))],
 					distance = NeP.Engine.Distance('player', Obj),
 					is = isDummy(Obj) and 'dummy' or 'enemie',
-					id = ID
+					id = ID,
+					guid = GUID
 				}
 			-- Object
 			elseif FireHack and ObjectIsType(Obj, ObjectTypes.GameObject) then
@@ -203,7 +206,8 @@ function NeP.OM.addToOM(Obj)
 					name = UnitName(Obj) or '',
 					distance = NeP.Engine.Distance('player', Obj),
 					is = 'object',
-					id = ID
+					id = ID,
+					guid = GUID
 				}
 			end
 		end


### PR DESCRIPTION
…M table

This is tested.  Now generic OM will not add duplicate units that are represented by multiple sources (e.g. mouseover + nameplate1)