### PR TITLE
fixing bugs related to helpers.lua module

### DIFF
--- a/files.xml
+++ b/files.xml
@@ -8,7 +8,7 @@
 	<Script file="external\LibBossIDs-1.0\LibBossIDs-1.0.lua" />
 	<Include file="external\CallbackHandler-1.0\CallbackHandler-1.0.xml" />
 	<Script file="external\LibRangeCheck-2.0\LibRangeCheck-2.0.lua" />
-	<Script file="external\AceAddon-3.0\AceAddon-3.0.lua" />	
+	<Script file="external\AceAddon-3.0\AceAddon-3.0.lua" />
 	<Script file="external\LibNameplateRegistry-1.0\LibNameplateRegistry-1.0.lua" />
 	<Script file="external\LibDispellable-1.0\LibDispellable-1.0.lua" />
 	<Script file="external\LibSharedMedia-3.0\LibSharedMedia-3.0.lua" />
@@ -40,7 +40,6 @@
 	<Script file="system\config.lua" />
 	<Script file="system\timeout.lua" />
 	<Script file="system\listener.lua" />
-	<Script file="system\helpers.lua" />
 	<Script file="system\listeners.lua" />
 
 	<!-- Interface -->
@@ -61,6 +60,7 @@
 	<Script file="system\conditions\keybinds.lua" />
 	<Script file="system\conditions\class.lua" />
 	<Script file="system\engine.lua" />
+	<Script file="system\helpers.lua" />
 	<Script file="system\healing.lua" />
 	<Script file="system\ObjectManager.lua" />
 	<Script file="system\commands.lua" />

--- a/system/helpers.lua
+++ b/system/helpers.lua
@@ -26,18 +26,18 @@ function NeP.Engine.Reset_Helpers()
 	NeP.pHelpers.behind = true
 	NeP.pHelpers.infront = true
 	NeP.pHelpers.range = true
-	wipe(pHelpers.range_failed)
+	wipe(NeP.pHelpers.range_failed)
 end
 
-function Engine.SpellRange(spell, target)
-	if not pHelpers.range then
-		if pHelpers.range_failed[spell] then
+function NeP.Engine.SpellRange(spell, target)
+	if not NeP.pHelpers.range then
+		if NeP.pHelpers.range_failed[spell] then
 			return false
 		end
-		pHelpers.range_failed[spell] = true
-		pHelpers.range  = true
+		NeP.pHelpers.range_failed[spell] = true
+		NeP.pHelpers.range  = true
 	end
-	return pHelpers.range and IsSpellInRange(spell, target) ~= 0
+	return NeP.pHelpers.range and IsSpellInRange(spell, target) ~= 0
 end
 
 NeP.Listener.register("UI_ERROR_MESSAGE", function(error)


### PR DESCRIPTION
There were some errors upon login related to the new helpers.lua module.  e.g. `system\helpers.lua:25: attempt to index field 'Engine' (a nil value)`

This PR moves helpers.lua in below engine.lua in the files.xml list since it is referencing NeP.Engine, and fixes some errors related to the references to pHelpers table.