### PR TITLE
[untested] prevent duplicate spells from queuing and add time decay

### DIFF
--- a/system/queue.lua
+++ b/system/queue.lua
@@ -3,6 +3,12 @@ local eQueue = {}
 local Engine = NeP.Engine
 
 function Engine.Cast_Queue(spell, target)
+	-- if the spell already exists in the queue do not add it again
+	for i=1, #eQueue do
+		if eQueue[i][1] = spell then
+			return false
+		end
+	end
 	eQueue[#eQueue+1] = {spell, nil, target}
 end
 

--- a/system/queue.lua
+++ b/system/queue.lua
@@ -9,7 +9,8 @@ function Engine.Cast_Queue(spell, target)
 			return false
 		end
 	end
-	eQueue[#eQueue+1] = {spell, nil, target}
+	local time = GetTime()
+	eQueue[#eQueue+1] = {spell, nil, target, time}
 end
 
 function Engine.clear_Cast_Queue()
@@ -18,6 +19,11 @@ end
 
 Engine.add_Sync('eQueue_parser', function()
 	for i=1, #eQueue do
+		local time = GetTime()
+		-- if the item in the queue has been there more than 5s, remove it
+		if ((time - eQueue[i][4]) > 5000) then
+			table.remove(eQueue, i)
+		end
 		if Engine.Parse({eQueue[i]}) then
 			table.remove(eQueue, i)
 		end

--- a/system/queue.lua
+++ b/system/queue.lua
@@ -5,7 +5,7 @@ local Engine = NeP.Engine
 function Engine.Cast_Queue(spell, target)
 	-- if the spell already exists in the queue do not add it again
 	for i=1, #eQueue do
-		if eQueue[i][1] = spell then
+		if eQueue[i][1] == spell then
 			return false
 		end
 	end


### PR DESCRIPTION
This is not yet tested but I want to submit something for your consideration in case you haven't through about doing this or have a way to implement it.  My feelings won't be hurt if you want to go about this a different way!

* [untested] if the spell already exists in the queue do not add it again