### PR TITLE
Fix functionality for specifying on/off on toggle command.

### DIFF
--- a/interface/mainframe.lua
+++ b/interface/mainframe.lua
@@ -185,7 +185,7 @@ Intf.toggleToggle = function(key, state)
 	button = _G[key]
 
 	if state ~= nil then
-		button.actv = state
+		button.actv = state == 'on'
 	else
 		button.actv = not button.actv
 	end

--- a/interface/mainframe.lua
+++ b/interface/mainframe.lua
@@ -180,10 +180,16 @@ Intf.CreateToggle = function(key, icon, name, tooltipz, callback)
 	Intf.RefreshToggles()
 end
 
-Intf.toggleToggle = function(key)
+Intf.toggleToggle = function(key, state)
 	local key = string.lower(key)
 	button = _G[key]
-	button.actv = not button.actv
+
+	if state ~= nil then
+		button.actv = state
+	else
+		button.actv = not button.actv
+	end
+
 	button:SetChecked(button.actv)
 	Config.Write('bStates_'..key, button.actv)	Intf.RefreshToggles()
 end

--- a/system/commands.lua
+++ b/system/commands.lua
@@ -16,23 +16,17 @@ end
 NeP_CMDTable = {
     -- Master Toggle
     ['mastertoggle'] = function(rest)
-		if rest == 'on' then
-			NeP.Interface.toggleToggle('MasterToggle', true)
-		elseif rest == 'off' then
-			NeP.Interface.toggleToggle('MasterToggle', false)
-		else
-			NeP.Interface.toggleToggle('MasterToggle')
-		end
+        NeP.Interface.toggleToggle('MasterToggle', rest)
 	end,
 	['mt'] = function(rest) NeP_CMDTable['mastertoggle'](rest) end,
 	['toggle'] = function(rest) NeP_CMDTable['mastertoggle'](rest) end,
 	['tg'] = function(rest) NeP_CMDTable['mastertoggle'](rest) end,
     -- AoE
-    ['aoe'] = function(rest) NeP.Interface.toggleToggle('AoE') end,
+    ['aoe'] = function(rest) NeP.Interface.toggleToggle('AoE', rest) end,
     -- CDs
-    ['cooldowns'] = function(rest) NeP.Interface.toggleToggle('Cooldowns') end,
+    ['cooldowns'] = function(rest) NeP.Interface.toggleToggle('Cooldowns', rest) end,
     -- Interrupts
-    ['interrupts'] = function(rest) NeP.Interface.toggleToggle('Interrupts') end,
+    ['interrupts'] = function(rest) NeP.Interface.toggleToggle('Interrupts', rest) end,
     -- Hide
     ['hide'] = function(rest) NePFrame:Hide(); NeP.Core.Print('To Display NerdPack Execute: \n/nep show') end,
 	-- Show


### PR DESCRIPTION
commands.lua indicated that "on"/"off" could be passed as another argument to the toggle commands, but this value was not being checked in the toggleToggle function.

Example:
/nep mt on
/nep mt off

Both of these commands were previously causing the same toggle functionality without forcing the toggle on or off. 