### PR TITLE
wiping combat tracker stuff when combat ends

### DIFF
--- a/system/combatTracker.lua
+++ b/system/combatTracker.lua
@@ -105,3 +105,7 @@ NeP.Listener.register('CombatTracker', 'COMBAT_LOG_EVENT_UNFILTERED', function(.
 	-- Add the amount of dmg/heak
 	if EVENTS[EVENT] then EVENTS[EVENT](...) end
 end)
+
+NeP.Listener.register('CombatTracker', 'PLAYER_REGEN_ENABLED', function(...)
+	Data = {}
+end)


### PR DESCRIPTION
Prior to this change, it appeared that the combat timer could never reset.