### PR TITLE
GCD fix

### DIFF
--- a/system/conditions/general.lua
+++ b/system/conditions/general.lua
@@ -187,8 +187,7 @@ RegisterConditon('gcd', function()
 	if class == 4 or (class == 11 and GetShapeshiftForm()== 2) then
 		return 1
 	end
-	local GCD = math.floor((1.5 / ((GetHaste() / 100) + 1)) * 10^3 ) / 10^3
-	return GCD
+	return math.floor((1.5 / ((GetHaste() / 100) + 1)) * 10^3 ) / 10^3
 end)
 
 RegisterConditon('UI', function(_, key)

--- a/system/conditions/general.lua
+++ b/system/conditions/general.lua
@@ -186,8 +186,8 @@ RegisterConditon('gcd', function()
     -- Some class's always have GCD = 1
     if class == 4 or (class == 11 and GetShapeshiftForm()== 2) then
         return 1
-    else
-		local GCD = math.floor((1.5 / ((GetHaste() / 100) + 1)) * 10^3 ) / 10^3    
+	else
+		local GCD = math.floor((1.5 / ((GetHaste() / 100) + 1)) * 10^3 ) / 10^3
 		return GCD
 	end
 end)

--- a/system/conditions/general.lua
+++ b/system/conditions/general.lua
@@ -180,11 +180,38 @@ end)
 RegisterConditon('equipped', function(_, item)
 	return IsEquippedItem(item)
 end)
-
+--[[
 RegisterConditon('gcd', function()
 	local GCD = math.floor((1.5 / ((GetHaste() / 100) + 1)) * 10^3 ) / 10^3	
 	return GCD
 end)
+
+RegisterConditon('gcd', function()
+    local class = select(3,UnitClass("player"))
+    -- Some class's always have GCD = 1
+    if class == 4 or (class == 11 and GetShapeshiftForm()== 2) then
+        return 1
+    end
+
+    local GCD = math.floor((1.5 / ((GetHaste() / 100) + 1)) * 10^3 ) / 10^3    
+    return GCD
+end)
+
+]]--
+
+RegisterConditon('gcd', function()
+    local class = select(3,UnitClass("player"))
+    -- Some class's always have GCD = 1
+    if class == 4 or (class == 11 and GetShapeshiftForm()== 2) then
+        return 1
+    else
+		local GCD = math.floor((1.5 / ((GetHaste() / 100) + 1)) * 10^3 ) / 10^3    
+		return GCD
+	end
+end)
+
+
+
 
 RegisterConditon('UI', function(_, key)
 	local SelectedCR = NeP.Interface.GetSelectedCR().Name

--- a/system/conditions/general.lua
+++ b/system/conditions/general.lua
@@ -180,24 +180,6 @@ end)
 RegisterConditon('equipped', function(_, item)
 	return IsEquippedItem(item)
 end)
---[[
-RegisterConditon('gcd', function()
-	local GCD = math.floor((1.5 / ((GetHaste() / 100) + 1)) * 10^3 ) / 10^3	
-	return GCD
-end)
-
-RegisterConditon('gcd', function()
-    local class = select(3,UnitClass("player"))
-    -- Some class's always have GCD = 1
-    if class == 4 or (class == 11 and GetShapeshiftForm()== 2) then
-        return 1
-    end
-
-    local GCD = math.floor((1.5 / ((GetHaste() / 100) + 1)) * 10^3 ) / 10^3    
-    return GCD
-end)
-
-]]--
 
 RegisterConditon('gcd', function()
     local class = select(3,UnitClass("player"))
@@ -209,9 +191,6 @@ RegisterConditon('gcd', function()
 		return GCD
 	end
 end)
-
-
-
 
 RegisterConditon('UI', function(_, key)
 	local SelectedCR = NeP.Interface.GetSelectedCR().Name

--- a/system/conditions/general.lua
+++ b/system/conditions/general.lua
@@ -182,7 +182,7 @@ RegisterConditon('equipped', function(_, item)
 end)
 
 RegisterConditon('gcd', function()
-	local _, GCD = GetSpellCooldown(61304)
+	local GCD = math.floor((1.5 / ((GetHaste() / 100) + 1)) * 10^3 ) / 10^3	
 	return GCD
 end)
 

--- a/system/conditions/general.lua
+++ b/system/conditions/general.lua
@@ -182,14 +182,13 @@ RegisterConditon('equipped', function(_, item)
 end)
 
 RegisterConditon('gcd', function()
-    local class = select(3,UnitClass("player"))
-    -- Some class's always have GCD = 1
-    if class == 4 or (class == 11 and GetShapeshiftForm()== 2) then
-        return 1
-	else
-		local GCD = math.floor((1.5 / ((GetHaste() / 100) + 1)) * 10^3 ) / 10^3
-		return GCD
+	local class = select(3,UnitClass("player"))
+	-- Some class's always have GCD = 1
+	if class == 4 or (class == 11 and GetShapeshiftForm()== 2) then
+		return 1
 	end
+	local GCD = math.floor((1.5 / ((GetHaste() / 100) + 1)) * 10^3 ) / 10^3
+	return GCD
 end)
 
 RegisterConditon('UI', function(_, key)

--- a/system/dispell.lua
+++ b/system/dispell.lua
@@ -33,7 +33,7 @@ local function SpellIsUsable(spell)
 	if spell and CheckSpell(spell, false)then
 		-- Make sure we can cast the spell
 		local start, duration, enabled = GetSpellCooldown(spell)
-		local _, GCD = GetSpellCooldown(61304)
+		local GCD = math.floor((1.5 / ((GetHaste() / 100) + 1)) * 10^3 ) / 10^3	
 		local isUsable, notEnoughMana = IsUsableSpell(spell)
 		if isUsable and (start <= GCD) and not notEnoughMana then
 			return true

--- a/system/dispell.lua
+++ b/system/dispell.lua
@@ -33,21 +33,7 @@ local function SpellIsUsable(spell)
 	if spell and CheckSpell(spell, false)then
 		-- Make sure we can cast the spell
 		local start, duration, enabled = GetSpellCooldown(spell)
-		-- this GCD works
-		local GCD = math.floor((1.5 / ((GetHaste() / 100) + 1)) * 10^3 ) / 10^3	
-		--[[
-		-- should work, maybe need debug also?
-		
-		local class = select(3,UnitClass("player"))
-		-- Some class's always have GCD = 1
-		if class == 4 or (class == 11 and GetShapeshiftForm()== 2) then
-			return 1
-		else
-			local GCD = math.floor((1.5 / ((GetHaste() / 100) + 1)) * 10^3 ) / 10^3    
-			return GCD
-		end
-		
-		]]--
+		local GCD = NeP.DSL.Get('gcd')()
 		local isUsable, notEnoughMana = IsUsableSpell(spell)
 		if isUsable and (start <= GCD) and not notEnoughMana then
 			return true

--- a/system/dispell.lua
+++ b/system/dispell.lua
@@ -33,7 +33,21 @@ local function SpellIsUsable(spell)
 	if spell and CheckSpell(spell, false)then
 		-- Make sure we can cast the spell
 		local start, duration, enabled = GetSpellCooldown(spell)
+		-- this GCD works
 		local GCD = math.floor((1.5 / ((GetHaste() / 100) + 1)) * 10^3 ) / 10^3	
+		--[[
+		-- should work, maybe need debug also?
+		
+		local class = select(3,UnitClass("player"))
+		-- Some class's always have GCD = 1
+		if class == 4 or (class == 11 and GetShapeshiftForm()== 2) then
+			return 1
+		else
+			local GCD = math.floor((1.5 / ((GetHaste() / 100) + 1)) * 10^3 ) / 10^3    
+			return GCD
+		end
+		
+		]]--
 		local isUsable, notEnoughMana = IsUsableSpell(spell)
 		if isUsable and (start <= GCD) and not notEnoughMana then
 			return true

--- a/system/engine.lua
+++ b/system/engine.lua
@@ -125,7 +125,6 @@ function Engine.spellResolve(spell)
 	local skillType = GetSpellBookItemInfo(spell)
 	local isUsable, notEnoughMana = IsUsableSpell(spell)
 	if skillType ~= 'FUTURESPELL' and isUsable and not notEnoughMana then
-		--this GCD works
 		local GCD = NeP.DSL.GET('gcd')()
 		if GetSpellCooldown(spell) <= GCD then
 			Engine.Current_Spell = spell

--- a/system/engine.lua
+++ b/system/engine.lua
@@ -126,20 +126,7 @@ function Engine.spellResolve(spell)
 	local isUsable, notEnoughMana = IsUsableSpell(spell)
 	if skillType ~= 'FUTURESPELL' and isUsable and not notEnoughMana then
 		--this GCD works
-		local GCD = math.floor((1.5 / ((GetHaste() / 100) + 1)) * 10^3 ) / 10^3	
-		--[[
-		-- does not work... need debug
-		
-		local class = select(3,UnitClass("player"))
-		-- Some class's always have GCD = 1
-		if class == 4 or (class == 11 and GetShapeshiftForm()== 2) then
-			return 1
-		else
-			local GCD = math.floor((1.5 / ((GetHaste() / 100) + 1)) * 10^3 ) / 10^3    
-			return GCD
-		end
-		
-		]]--
+		local GCD = NeP.DSL.GET('gcd')()
 		if GetSpellCooldown(spell) <= GCD then
 			Engine.Current_Spell = spell
 			return spell

--- a/system/engine.lua
+++ b/system/engine.lua
@@ -125,7 +125,21 @@ function Engine.spellResolve(spell)
 	local skillType = GetSpellBookItemInfo(spell)
 	local isUsable, notEnoughMana = IsUsableSpell(spell)
 	if skillType ~= 'FUTURESPELL' and isUsable and not notEnoughMana then
+		--this GCD works
 		local GCD = math.floor((1.5 / ((GetHaste() / 100) + 1)) * 10^3 ) / 10^3	
+		--[[
+		-- does not work... need debug
+		
+		local class = select(3,UnitClass("player"))
+		-- Some class's always have GCD = 1
+		if class == 4 or (class == 11 and GetShapeshiftForm()== 2) then
+			return 1
+		else
+			local GCD = math.floor((1.5 / ((GetHaste() / 100) + 1)) * 10^3 ) / 10^3    
+			return GCD
+		end
+		
+		]]--
 		if GetSpellCooldown(spell) <= GCD then
 			Engine.Current_Spell = spell
 			return spell

--- a/system/engine.lua
+++ b/system/engine.lua
@@ -125,7 +125,7 @@ function Engine.spellResolve(spell)
 	local skillType = GetSpellBookItemInfo(spell)
 	local isUsable, notEnoughMana = IsUsableSpell(spell)
 	if skillType ~= 'FUTURESPELL' and isUsable and not notEnoughMana then
-		local _, GCD = GetSpellCooldown(61304)
+		local GCD = math.floor((1.5 / ((GetHaste() / 100) + 1)) * 10^3 ) / 10^3	
 		if GetSpellCooldown(spell) <= GCD then
 			Engine.Current_Spell = spell
 			return spell


### PR DESCRIPTION
Don't use GetSpellCooldown(61304) to get GCD value.

Problem with this is you get right GCD value **ONLY** if you call this while GCD is already triggered, which means if you need get GCD value with GetSpellCooldown(61304) **WHILE** using spells with casting time longer than GCD, auto-attacking, using off-GCD skills,you are out-of-combat,etc... = **GCD value is 0 !** >.<

my fix give you right value everytime :)
