### PR TITLE
NeP.Tooltip:Unit: Adding an additional check

### DIFF
--- a/system/tooltip.lua
+++ b/system/tooltip.lua
@@ -41,6 +41,7 @@ function NeP.Tooltip:Unit(target, pattern)
 	frame:SetOwner(UIParent, 'ANCHOR_NONE')
 	frame:SetUnit(target)
 	local tooltipText = _G["NeP_ScanningTooltipTextLeft2"]:GetText()
+	if pPattern(UnitName(target):lower(), pattern) then return true end
 	return tooltipText and pPattern(tooltipText, pattern)
 end
 


### PR DESCRIPTION
Fixes #127

NeP.Tooltip:Unit was only matching on tooltip subtext (things like 'Mechanical' or 'Level 110' instead)
Add a secondary pPattern search on UnitName in addition to tooltipText, fixes the issue
It may not even be necessary to search on tooltipText but I'll leave that for someone else to decide