### PR TITLE
Fix petrange

### DIFF
--- a/conditions/class.lua
+++ b/conditions/class.lua
@@ -50,6 +50,7 @@ NeP.DSL:Register('insanity', function(target)
 end)
 
 NeP.DSL:Register('petrange', function(target)
+	if not UnitExists('pet') then return false end
   return target and NeP.Protected.Distance('pet', target) or 0
 end)
 


### PR DESCRIPTION
This fixes a GUID issue that often occurs when using "petrange" with FireHack.
If the unit (pet) doesn't exist FireHack/NerdPack will crash with a GUID error, needing a reload to work again.

This happens for example when you're mounted and fly into combat.
The pet doesn't exist the moment combat starts, and NerdPack crashes.